### PR TITLE
QALI-104 Misc fixes

### DIFF
--- a/api/api-dsl/build.gradle.kts
+++ b/api/api-dsl/build.gradle.kts
@@ -32,9 +32,13 @@ val micronautVersion: String by project
 val kotlinCoroutinesVersion: String by project
 val catadioptreVersion: String by project
 
+kotlin.sourceSets["test"].kotlin.srcDir("build/generated/source/kaptKotlin/catadioptre")
+kapt.useBuildCache = false
+
 dependencies {
     compileOnly(platform("io.micronaut:micronaut-bom:${micronautVersion}"))
     compileOnly("org.graalvm.nativeimage:svm")
+    compileOnly("io.aeris-consulting:catadioptre-annotations:${catadioptreVersion}")
 
     compileOnly(kotlin("stdlib"))
     implementation(project(":api:api-dev"))
@@ -54,6 +58,7 @@ dependencies {
     kapt("io.micronaut:micronaut-inject-java")
     kapt("io.micronaut:micronaut-validation")
     kapt("io.micronaut:micronaut-graal")
+    kapt("io.aeris-consulting:catadioptre-annotations:${catadioptreVersion}")
 
     testImplementation(project(":test"))
     testImplementation(testFixtures(project(":api:api-common")))

--- a/api/api-dsl/src/main/kotlin/io/qalipsis/api/scenario/DefaultScenarioSpecificationsKeeper.kt
+++ b/api/api-dsl/src/main/kotlin/io/qalipsis/api/scenario/DefaultScenarioSpecificationsKeeper.kt
@@ -1,5 +1,6 @@
 package io.qalipsis.api.scenario
 
+import io.aerisconsulting.catadioptre.KTestable
 import io.micronaut.context.annotation.Property
 import io.qalipsis.api.context.ScenarioId
 import jakarta.inject.Singleton
@@ -30,6 +31,10 @@ internal class DefaultScenarioSpecificationsKeeper(
         }
     }
 
+    override fun clear() {
+        scenariosSpecifications.clear()
+    }
+
     override fun asMap(): Map<ScenarioId, ConfiguredScenarioSpecification> {
         return filterScenarios(scenariosSpecifications)
     }
@@ -37,8 +42,8 @@ internal class DefaultScenarioSpecificationsKeeper(
     /**
      * Filters out the scenarios that are not matching the existing selectors. When no selector is set, [scenarios] is returned.
      */
-    // Visible for test.
-    internal fun filterScenarios(scenarios: Map<ScenarioId, ConfiguredScenarioSpecification>): Map<ScenarioId, ConfiguredScenarioSpecification> {
+    @KTestable
+    private fun filterScenarios(scenarios: Map<ScenarioId, ConfiguredScenarioSpecification>): Map<ScenarioId, ConfiguredScenarioSpecification> {
         return if (exactMatchers.isEmpty() && patternMatchers.isEmpty()) {
             scenarios
         } else scenarios.filterKeys { scenarioId ->

--- a/api/api-dsl/src/main/kotlin/io/qalipsis/api/scenario/ScenarioSpecificationImplementation.kt
+++ b/api/api-dsl/src/main/kotlin/io/qalipsis/api/scenario/ScenarioSpecificationImplementation.kt
@@ -1,5 +1,6 @@
 package io.qalipsis.api.scenario
 
+import io.aerisconsulting.catadioptre.KTestable
 import io.qalipsis.api.context.DirectedAcyclicGraphId
 import io.qalipsis.api.context.StepName
 import io.qalipsis.api.lang.concurrentList
@@ -26,8 +27,8 @@ internal class ScenarioSpecificationImplementation(
 
     override val rootSteps = concurrentList<StepSpecification<*, *, *>>()
 
-    // Visible for test only.
-    internal val registeredSteps = ConcurrentHashMap<String, ImmutableSlot<StepSpecification<*, *, *>>>()
+    @KTestable
+    private val registeredSteps = ConcurrentHashMap<String, ImmutableSlot<StepSpecification<*, *, *>>>()
 
     override var rampUpStrategy: RampUpStrategy? = null
 

--- a/api/api-dsl/src/main/kotlin/io/qalipsis/api/scenario/ScenarioSpecificationsKeeper.kt
+++ b/api/api-dsl/src/main/kotlin/io/qalipsis/api/scenario/ScenarioSpecificationsKeeper.kt
@@ -9,5 +9,13 @@ import io.qalipsis.api.context.ScenarioId
  */
 interface ScenarioSpecificationsKeeper {
 
+    /**
+     * Clears the scenario specifications in the factory.
+     */
+    fun clear()
+
+    /**
+     * Returns the map of specifications in the factory.
+     */
     fun asMap(): Map<ScenarioId, ConfiguredScenarioSpecification>
 }

--- a/api/api-dsl/src/main/kotlin/io/qalipsis/api/steps/MapWithContextStepSpecification.kt
+++ b/api/api-dsl/src/main/kotlin/io/qalipsis/api/steps/MapWithContextStepSpecification.kt
@@ -1,0 +1,31 @@
+package io.qalipsis.api.steps
+
+import io.micronaut.core.annotation.Introspected
+import io.qalipsis.api.context.StepContext
+
+/**
+ * Specification for a [io.qalipsis.core.factories.steps.MapWithContextStep].
+ *
+ * @author Eric Jessé
+ */
+@Introspected
+data class MapWithContextStepSpecification<INPUT, OUTPUT>(
+    val block: (context: StepContext<INPUT, OUTPUT>, input: INPUT) -> OUTPUT
+) : AbstractStepSpecification<INPUT, OUTPUT, MapWithContextStepSpecification<INPUT, OUTPUT>>()
+
+/**
+ * Converts any input into a different output, also considering the context.
+ *
+ * @param block the rule to convert the input and the context into the output.
+ *
+ * @author Eric Jessé
+ */
+fun <INPUT, OUTPUT> StepSpecification<*, INPUT, *>.mapWithContext(
+    @Suppress(
+        "UNCHECKED_CAST"
+    ) block: (context: StepContext<INPUT, OUTPUT>, input: INPUT) -> OUTPUT = { context, value -> value as OUTPUT }
+): MapWithContextStepSpecification<INPUT, OUTPUT> {
+    val step = MapWithContextStepSpecification(block)
+    this.add(step)
+    return step
+}

--- a/api/api-dsl/src/main/kotlin/io/qalipsis/api/steps/ShelveStepSpecification.kt
+++ b/api/api-dsl/src/main/kotlin/io/qalipsis/api/steps/ShelveStepSpecification.kt
@@ -10,7 +10,7 @@ import javax.validation.constraints.NotBlank
  */
 @Introspected
 data class ShelveStepSpecification<INPUT>(
-        val specification: (input: INPUT) -> Map<@NotBlank String, Any?>
+    val specification: (input: INPUT) -> Map<@NotBlank String, Any?>
 ) : AbstractStepSpecification<INPUT, INPUT, ShelveStepSpecification<INPUT>>()
 
 /**
@@ -21,7 +21,8 @@ data class ShelveStepSpecification<INPUT>(
  * @author Eric Jessé
  */
 fun <INPUT> StepSpecification<*, INPUT, *>.shelve(
-        specification: (input: INPUT) -> Map<String, Any?>): ShelveStepSpecification<INPUT> {
+    specification: (input: INPUT) -> Map<String, Any?>
+): ShelveStepSpecification<INPUT> {
     val step = ShelveStepSpecification(specification)
     this.add(step)
     return step
@@ -36,4 +37,19 @@ fun <INPUT> StepSpecification<*, INPUT, *>.shelve(
  */
 fun <INPUT> StepSpecification<*, INPUT, *>.shelve(name: String): ShelveStepSpecification<INPUT> {
     return this.shelve { input -> mapOf(name to input) }
+}
+
+
+/**
+ * Shelves the input into a cache for later use with the given name.
+ *
+ * @param name name of the value to later [unshelve] in the cache.
+ *
+ * @author Eric Jessé
+ */
+fun <INPUT> StepSpecification<*, INPUT, *>.shelve(
+    name: String,
+    specification: (input: INPUT) -> Any?
+): ShelveStepSpecification<INPUT> {
+    return this.shelve { input -> mapOf(name to specification(input)) }
 }

--- a/api/api-dsl/src/main/kotlin/io/qalipsis/api/steps/VerificationStepSpecification.kt
+++ b/api/api-dsl/src/main/kotlin/io/qalipsis/api/steps/VerificationStepSpecification.kt
@@ -41,10 +41,10 @@ fun <INPUT, OUTPUT> StepSpecification<*, INPUT, *>.verifyAndMap(
  */
 fun <INPUT> StepSpecification<*, INPUT, *>.verify(
         assertionBlock: (suspend (input: INPUT) -> Unit)): VerificationStepSpecification<INPUT, INPUT> {
-    val step = VerificationStepSpecification<INPUT, INPUT>({ value ->
+    val step = VerificationStepSpecification<INPUT, INPUT> { value ->
         assertionBlock(value)
         value
-    })
+    }
     this.add(step)
     return step
 }

--- a/api/api-dsl/src/test/kotlin/io/qalipsis/api/ScenarioSpecificationImplementationTest.kt
+++ b/api/api-dsl/src/test/kotlin/io/qalipsis/api/ScenarioSpecificationImplementationTest.kt
@@ -6,13 +6,20 @@ import assertk.assertions.containsAll
 import assertk.assertions.isNotEqualTo
 import assertk.assertions.isNotNull
 import io.qalipsis.api.rampup.RampUpStrategy
-import io.qalipsis.api.scenario.*
+import io.qalipsis.api.scenario.ConfiguredScenarioSpecification
+import io.qalipsis.api.scenario.ScenarioSpecificationImplementation
+import io.qalipsis.api.scenario.StepSpecificationRegistry
+import io.qalipsis.api.scenario.catadioptre.registeredSteps
+import io.qalipsis.api.scenario.scenario
+import io.qalipsis.api.scenario.scenariosSpecifications
 import io.qalipsis.api.steps.AbstractStepSpecification
 import io.qalipsis.api.steps.SingletonConfiguration
 import io.qalipsis.api.steps.SingletonStepSpecification
 import io.qalipsis.test.mockk.relaxedMockk
 import kotlinx.coroutines.test.runBlockingTest
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.assertThrows
@@ -72,7 +79,7 @@ internal class ScenarioSpecificationImplementationTest {
         assertTrue(scenario.rootSteps.isNotEmpty())
         assertSame(step, scenario.rootSteps[0])
 
-        assertTrue(scenario.registeredSteps.isEmpty())
+        assertTrue(scenario.registeredSteps().isEmpty())
     }
 
     @Test
@@ -88,7 +95,7 @@ internal class ScenarioSpecificationImplementationTest {
         assertTrue(scenario.rootSteps.isNotEmpty())
         assertSame(step, scenario.rootSteps[0])
 
-        assertTrue(scenario.registeredSteps.isEmpty())
+        assertTrue(scenario.registeredSteps().isEmpty())
     }
 
     @Test

--- a/api/api-dsl/src/test/kotlin/io/qalipsis/api/scenario/DefaultScenarioSpecificationsKeeperTest.kt
+++ b/api/api-dsl/src/test/kotlin/io/qalipsis/api/scenario/DefaultScenarioSpecificationsKeeperTest.kt
@@ -5,6 +5,8 @@ import assertk.assertThat
 import assertk.assertions.hasSize
 import assertk.assertions.isNotNull
 import assertk.assertions.key
+import io.qalipsis.api.context.ScenarioId
+import io.qalipsis.api.scenario.catadioptre.filterScenarios
 import io.qalipsis.test.mockk.relaxedMockk
 import org.junit.jupiter.api.Test
 import java.util.Optional
@@ -25,7 +27,7 @@ internal class DefaultScenarioSpecificationsKeeperTest {
             "my-first-scenario" to relaxedMockk { },
             "my-second-scenario" to relaxedMockk { },
             "my-third-scenario" to relaxedMockk { }
-        ))
+        )) as Map<*, *>
 
         // then
         assertThat(eligibleScenarios).hasSize(3)
@@ -41,7 +43,7 @@ internal class DefaultScenarioSpecificationsKeeperTest {
             "my-first-scenario" to relaxedMockk { },
             "my-second-scenario" to relaxedMockk { },
             "my-third-scenario" to relaxedMockk { }
-        ))
+        )) as Map<*, *>
 
         // then
         assertThat(eligibleScenarios).hasSize(3)
@@ -57,7 +59,7 @@ internal class DefaultScenarioSpecificationsKeeperTest {
             "my-first-scenario" to relaxedMockk { },
             "my-second-scenario" to relaxedMockk { },
             "my-third-scenario" to relaxedMockk { }
-        ))
+        )) as Map<*, *>
 
         // then
         assertThat(eligibleScenarios).hasSize(3)
@@ -77,7 +79,7 @@ internal class DefaultScenarioSpecificationsKeeperTest {
             "my-fourth-scenario" to relaxedMockk { },
             "my-fifth-scenario" to relaxedMockk { },
             "my-sixth-scenario" to relaxedMockk { }
-        ))
+        )) as Map<ScenarioId, *>
 
         // then
         assertThat(eligibleScenarios).all {

--- a/api/api-dsl/src/test/kotlin/io/qalipsis/api/steps/MapWithContextStepSpecificationTest.kt
+++ b/api/api-dsl/src/test/kotlin/io/qalipsis/api/steps/MapWithContextStepSpecificationTest.kt
@@ -1,0 +1,20 @@
+package io.qalipsis.api.steps
+
+import io.qalipsis.api.context.StepContext
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * @author Eric Jessé
+ */
+internal class MapWithContextStepSpecificationTest {
+
+    @Test
+    internal fun `should add mapWithContext step as next`() {
+        val previousStep = DummyStepSpecification()
+        val specification: (context: StepContext<Int, String>, input: Int) -> String = { _, value -> value.toString() }
+        previousStep.mapWithContext(specification)
+
+        assertEquals(MapWithContextStepSpecification(specification), previousStep.nextSteps[0])
+    }
+}

--- a/api/api-dsl/src/test/kotlin/io/qalipsis/api/steps/ShelveStepSpecificationTest.kt
+++ b/api/api-dsl/src/test/kotlin/io/qalipsis/api/steps/ShelveStepSpecificationTest.kt
@@ -25,4 +25,12 @@ internal class ShelveStepSpecificationTest {
 
         assertTrue(previousStep.nextSteps[0] is ShelveStepSpecification)
     }
+
+    @Test
+    internal fun `should add shelve step with unique name and specification as next`() {
+        val previousStep = DummyStepSpecification()
+        previousStep.shelve("value-1") { input -> input.toString() }
+
+        assertTrue(previousStep.nextSteps[0] is ShelveStepSpecification)
+    }
 }

--- a/core/src/main/kotlin/io/qalipsis/core/factories/orchestration/ScenariosInitializer.kt
+++ b/core/src/main/kotlin/io/qalipsis/core/factories/orchestration/ScenariosInitializer.kt
@@ -16,4 +16,9 @@ package io.qalipsis.core.factories.orchestration
  */
 internal interface ScenariosInitializer {
 
+    /**
+     * Refreshes the scenarios
+     */
+    fun refresh()
+
 }

--- a/core/src/main/kotlin/io/qalipsis/core/factories/steps/MapWithContextStep.kt
+++ b/core/src/main/kotlin/io/qalipsis/core/factories/steps/MapWithContextStep.kt
@@ -1,0 +1,25 @@
+package io.qalipsis.core.factories.steps
+
+import io.qalipsis.api.context.StepContext
+import io.qalipsis.api.context.StepId
+import io.qalipsis.api.retry.RetryPolicy
+import io.qalipsis.api.steps.AbstractStep
+
+/**
+ * Step to transform a record.
+ *
+ * @author Eric Jessé
+ */
+internal class MapWithContextStep<I, O>(
+    id: StepId,
+    retryPolicy: RetryPolicy?,
+    @Suppress("UNCHECKED_CAST") private val block: ((context: StepContext<I, O>, input: I) -> O) = { _, value -> value as O }
+) : AbstractStep<I, O>(id, retryPolicy) {
+
+    override suspend fun execute(context: StepContext<I, O>) {
+        val input = context.receive()
+        val output = block(context, input)
+        context.send(output)
+    }
+
+}

--- a/core/src/main/kotlin/io/qalipsis/core/factories/steps/converters/MapStepSpecificationConverter.kt
+++ b/core/src/main/kotlin/io/qalipsis/core/factories/steps/converters/MapStepSpecificationConverter.kt
@@ -1,16 +1,14 @@
 package io.qalipsis.core.factories.steps.converters
 
 import io.qalipsis.api.annotations.StepConverter
-import io.qalipsis.api.steps.FlatMapStepSpecification
 import io.qalipsis.api.steps.MapStepSpecification
 import io.qalipsis.api.steps.StepCreationContext
 import io.qalipsis.api.steps.StepSpecification
 import io.qalipsis.api.steps.StepSpecificationConverter
-import io.qalipsis.core.factories.steps.FlatMapStep
 import io.qalipsis.core.factories.steps.MapStep
 
 /**
- * [StepSpecificationConverter] from [FlatMapStepSpecification] to [FlatMapStep].
+ * [StepSpecificationConverter] from [MapStepSpecification] to [MapStep].
  *
  * @author Eric Jessé
  */

--- a/core/src/main/kotlin/io/qalipsis/core/factories/steps/converters/MapWithContextStepSpecificationConverter.kt
+++ b/core/src/main/kotlin/io/qalipsis/core/factories/steps/converters/MapWithContextStepSpecificationConverter.kt
@@ -1,0 +1,33 @@
+package io.qalipsis.core.factories.steps.converters
+
+import io.qalipsis.api.annotations.StepConverter
+import io.qalipsis.api.steps.MapWithContextStepSpecification
+import io.qalipsis.api.steps.StepCreationContext
+import io.qalipsis.api.steps.StepSpecification
+import io.qalipsis.api.steps.StepSpecificationConverter
+import io.qalipsis.core.factories.steps.MapWithContextStep
+
+/**
+ * [StepSpecificationConverter] from [MapWithContextStepSpecification] to [MapWithContextStep].
+ *
+ * @author Eric Jessé
+ */
+@StepConverter
+internal class MapWithContextStepSpecificationConverter :
+    StepSpecificationConverter<MapWithContextStepSpecification<*, *>> {
+
+    override fun support(stepSpecification: StepSpecification<*, *, *>): Boolean {
+        return stepSpecification is MapWithContextStepSpecification
+    }
+
+    override suspend fun <I, O> convert(creationContext: StepCreationContext<MapWithContextStepSpecification<*, *>>) {
+        @Suppress("UNCHECKED_CAST")
+        val spec = creationContext.stepSpecification as MapWithContextStepSpecification<I, O>
+        val step = MapWithContextStep(
+            spec.name,
+            spec.retryPolicy ?: creationContext.directedAcyclicGraph.scenario.defaultRetryPolicy, spec.block
+        )
+        creationContext.createdStep(step)
+    }
+
+}

--- a/core/src/main/kotlin/io/qalipsis/core/report/StandaloneConsoleReportPublisher.kt
+++ b/core/src/main/kotlin/io/qalipsis/core/report/StandaloneConsoleReportPublisher.kt
@@ -5,6 +5,8 @@ import io.micronaut.context.annotation.Property
 import io.micronaut.context.annotation.Requirements
 import io.micronaut.context.annotation.Requires
 import io.qalipsis.api.context.CampaignId
+import io.qalipsis.api.lang.tryAndLogOrNull
+import io.qalipsis.api.logging.LoggerHelper.logger
 import io.qalipsis.api.report.CampaignStateKeeper
 import io.qalipsis.api.report.ReportPublisher
 import io.qalipsis.core.cross.configuration.ENV_AUTOSTART
@@ -84,12 +86,17 @@ ${
 
     @PreDestroy
     fun publishOnLeave() {
-        runBlocking {
-            publish(campaignName)
+        tryAndLogOrNull(log) {
+            runBlocking {
+                publish(campaignName)
+            }
         }
     }
 
     companion object {
+
+        @JvmStatic
+        private val log = logger()
 
         private const val RUNNING_INDICATOR = "<Running>"
 

--- a/core/src/test/kotlin/io/qalipsis/core/factories/steps/MapWithContextStepTest.kt
+++ b/core/src/test/kotlin/io/qalipsis/core/factories/steps/MapWithContextStepTest.kt
@@ -1,0 +1,38 @@
+package io.qalipsis.core.factories.steps
+
+import io.qalipsis.test.steps.StepTestHelper
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+internal class MapWithContextStepTest {
+
+    @Test
+    @Timeout(1)
+    fun `should simply forward with default step`() = runBlockingTest {
+        val step = MapWithContextStep<Int, Int>("", null)
+        val ctx = StepTestHelper.createStepContext<Int, Int>(input = 1)
+
+        step.execute(ctx)
+        val output = (ctx.output as Channel).receive()
+        assertEquals(1, output)
+        assertFalse((ctx.output as Channel).isClosedForReceive)
+
+    }
+
+    @Test
+    @Timeout(1)
+    fun `should apply mapping`() = runBlockingTest {
+        val step =
+            MapWithContextStep<Int, String>("", null) { context, value -> context.minionId + "-" + value.toString() }
+        val ctx = StepTestHelper.createStepContext<Int, String>(input = 1)
+
+        step.execute(ctx)
+        val output = (ctx.output as Channel).receive()
+        assertEquals(ctx.minionId + "-1", output)
+        assertFalse((ctx.output as Channel).isClosedForReceive)
+    }
+}

--- a/core/src/test/kotlin/io/qalipsis/core/factories/steps/converters/MapWithContextStepSpecificationConverterTest.kt
+++ b/core/src/test/kotlin/io/qalipsis/core/factories/steps/converters/MapWithContextStepSpecificationConverterTest.kt
@@ -1,0 +1,80 @@
+package io.qalipsis.core.factories.steps.converters
+
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isSameAs
+import assertk.assertions.prop
+import io.mockk.every
+import io.qalipsis.api.context.StepContext
+import io.qalipsis.api.steps.MapWithContextStepSpecification
+import io.qalipsis.api.steps.StepCreationContext
+import io.qalipsis.api.steps.StepCreationContextImpl
+import io.qalipsis.core.factories.steps.MapWithContextStep
+import io.qalipsis.test.assertk.prop
+import io.qalipsis.test.mockk.relaxedMockk
+import io.qalipsis.test.steps.AbstractStepSpecificationConverterTest
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+@Suppress("UNCHECKED_CAST")
+internal class MapWithContextStepSpecificationConverterTest :
+    AbstractStepSpecificationConverterTest<MapWithContextStepSpecificationConverter>() {
+
+    @Test
+    override fun `should support expected spec`() {
+        // when+then
+        assertTrue(converter.support(relaxedMockk<MapWithContextStepSpecification<*, *>>()))
+    }
+
+    @Test
+    override fun `should not support unexpected spec`() {
+        // when+then
+        assertFalse(converter.support(relaxedMockk()))
+    }
+
+    @Test
+    internal fun `should convert spec with name and retry policy to step`() = runBlockingTest {
+        // given
+        val blockSpecification: ((context: StepContext<Int, String>, input: Int) -> String) =
+            { _, value -> value.toString() }
+        val spec = MapWithContextStepSpecification(blockSpecification)
+        spec.name = "my-step"
+        spec.retryPolicy = mockedRetryPolicy
+        val creationContext = StepCreationContextImpl(scenarioSpecification, directedAcyclicGraph, spec)
+
+        // when
+        converter.convert<String, Int>(creationContext as StepCreationContext<MapWithContextStepSpecification<*, *>>)
+
+        // then
+        assertThat(creationContext.createdStep!!).isInstanceOf(MapWithContextStep::class).all {
+            prop(MapWithContextStep<*, *>::id).isEqualTo("my-step")
+            prop(MapWithContextStep<*, *>::retryPolicy).isSameAs(mockedRetryPolicy)
+            prop("block").isSameAs(blockSpecification)
+        }
+    }
+
+    @Test
+    internal fun `should convert spec without name nor retry policy to step`() = runBlockingTest {
+        // given
+        val blockSpecification: ((context: StepContext<Int, String>, input: Int) -> String) =
+            { _, value -> value.toString() }
+        val spec = MapWithContextStepSpecification(blockSpecification)
+        every { directedAcyclicGraph.scenario.defaultRetryPolicy } returns mockedRetryPolicy
+        val creationContext = StepCreationContextImpl(relaxedMockk(), directedAcyclicGraph, spec)
+
+        // when
+        converter.convert<String, Int>(creationContext as StepCreationContext<MapWithContextStepSpecification<*, *>>)
+
+        // then
+        assertThat(creationContext.createdStep!!).isInstanceOf(MapWithContextStep::class).all {
+            prop(MapWithContextStep<*, *>::id).isEmpty()
+            prop(MapWithContextStep<*, *>::retryPolicy).isSameAs(mockedRetryPolicy)
+            prop("block").isSameAs(blockSpecification)
+        }
+    }
+
+}

--- a/core/src/test/kotlin/io/qalipsis/core/heads/campaigns/CampaignAutoStarterTest.kt
+++ b/core/src/test/kotlin/io/qalipsis/core/heads/campaigns/CampaignAutoStarterTest.kt
@@ -180,7 +180,7 @@ internal class CampaignAutoStarterTest {
             campaignAutoStarter.runningScenariosLatch(runningScenariosLatch)
 
             // when
-            repeat(2) { index ->
+            repeat(2) {
                 campaignAutoStarter.coInvokeInvisible<Unit>(
                     "receivedFeedback",
                     FactoryRegistrationFeedback(emptyList())

--- a/user-documentation/src/main/asciidoc/sections/05_steps.adoc
+++ b/user-documentation/src/main/asciidoc/sections/05_steps.adoc
@@ -226,16 +226,20 @@ Converts a collective input into single element in the output, using the user-de
 image:operators/flatMap.svg[operators-flatMap]
 
 ===== flatten
+
 Converts a collective input into single element in the output, for a known collective type (array, iterable).
 
 image:operators/flatten.svg[operators-flatten]
 
 ===== map
+
 Converts each element into another in the output.
+`mapWithContext` provides the same capability with the step context as additional argument.
 
 image:operators/map.svg[operators-map]
 
 ===== onEach
+
 Executes one or several statements on each element of the input, and forwards them unchanged to the output.
 
 image:operators/onEach.svg[operators-onEach]


### PR DESCRIPTION
- Set a timeout when search a step from another in the scenario conversion
- Create a mapWithContext
- Create shelve(name) { valueExtractor }
- When the scenario cannot be converted or the campaign cannot start, the console report should not be SUCCESSFUL (end and duration are still "<RUNNING>")